### PR TITLE
Feature/attempt tracking

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -241,6 +241,8 @@
         return;
     }
 
+    [self.delegate bannerWillStartAttemptForAdManager:self withCustomEventClass:NSStringFromClass(self.requestingConfiguration.customEventClass)];
+    
     [self.requestingAdapter _getAdWithConfiguration:self.requestingConfiguration containerSize:self.delegate.containerSize];
 }
 
@@ -318,6 +320,8 @@
 
 - (void)adapter:(MPBaseBannerAdapter *)adapter didFailToLoadAdWithError:(NSError *)error
 {
+    [self.delegate bannerDidFailAttemptForAdManager:self withCustomEventClass:NSStringFromClass(self.requestingConfiguration.customEventClass)];
+    
     if (self.requestingAdapter == adapter) {
         [self loadAdWithURL:self.requestingConfiguration.failoverURL];
     }

--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -320,7 +320,7 @@
 
 - (void)adapter:(MPBaseBannerAdapter *)adapter didFailToLoadAdWithError:(NSError *)error
 {
-    [self.delegate bannerDidFailAttemptForAdManager:self withCustomEventClass:NSStringFromClass(self.requestingConfiguration.customEventClass)];
+    [self.delegate bannerDidFailAttemptForAdManager:self withCustomEventClass:NSStringFromClass(self.requestingConfiguration.customEventClass) error:error];
     
     if (self.requestingAdapter == adapter) {
         [self loadAdWithURL:self.requestingConfiguration.failoverURL];

--- a/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
@@ -25,7 +25,7 @@
 - (void)invalidateContentView;
 
 - (void)bannerWillStartAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
-- (void)bannerDidFailAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
+- (void)bannerDidFailAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass error:(NSError*)error;
 
 - (void)managerDidLoadAd:(UIView *)ad;
 - (void)managerDidFailToLoadAd;

--- a/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
@@ -24,6 +24,9 @@
 
 - (void)invalidateContentView;
 
+- (void)bannerWillStartAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
+- (void)bannerDidFailAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
+
 - (void)managerDidLoadAd:(UIView *)ad;
 - (void)managerDidFailToLoadAd;
 - (void)userActionWillBegin;

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -170,6 +170,10 @@
         return;
     }
 
+    [self.delegate managerWillStartInterstitialAttempt:self
+                                  withCustomEventClass:NSStringFromClass(configuration.customEventClass)
+                                            creativeId:configuration.creativeId];
+    
     MPBaseInterstitialAdapter *adapter = [[MPInterstitialCustomEventAdapter alloc] initWithDelegate:self];
 
     self.adapter = adapter;
@@ -187,6 +191,9 @@
 
 - (void)adapter:(MPBaseInterstitialAdapter *)adapter didFailToLoadAdWithError:(NSError *)error
 {
+    [self.delegate managerDidFailInterstitialAttempt:self
+                                withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
+                                          creativeId:self.configuration.creativeId];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -189,7 +189,7 @@
 
 - (void)adapter:(MPBaseInterstitialAdapter *)adapter didFailToLoadAdWithError:(NSError *)error
 {
-    [self.delegate manager:self didFailInterstitialAttemptWithCustomEventClass:NSStringFromClass(self.configuration.customEventClass)];
+    [self.delegate manager:self didFailInterstitialAttemptWithCustomEventClass:NSStringFromClass(self.configuration.customEventClass) error:error];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -170,9 +170,7 @@
         return;
     }
 
-    [self.delegate managerWillStartInterstitialAttempt:self
-                                  withCustomEventClass:NSStringFromClass(configuration.customEventClass)
-                                            creativeId:configuration.creativeId];
+    [self.delegate manager:self willStartInterstitialAttemptWithCustomEventClass:NSStringFromClass(configuration.customEventClass)];
     
     MPBaseInterstitialAdapter *adapter = [[MPInterstitialCustomEventAdapter alloc] initWithDelegate:self];
 
@@ -191,9 +189,7 @@
 
 - (void)adapter:(MPBaseInterstitialAdapter *)adapter didFailToLoadAdWithError:(NSError *)error
 {
-    [self.delegate managerDidFailInterstitialAttempt:self
-                                withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
-                                          creativeId:self.configuration.creativeId];
+    [self.delegate manager:self didFailInterstitialAttemptWithCustomEventClass:NSStringFromClass(self.configuration.customEventClass)];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManagerDelegate.h
@@ -17,8 +17,8 @@
 - (CLLocation *)location;
 - (id)interstitialDelegate;
 
-- (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
-- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+- (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass;
+- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass;
 
 - (void)managerDidLoadInterstitial:(MPInterstitialAdManager *)manager;
 - (void)manager:(MPInterstitialAdManager *)manager

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManagerDelegate.h
@@ -16,6 +16,10 @@
 - (MPInterstitialAdController *)interstitialAdController;
 - (CLLocation *)location;
 - (id)interstitialDelegate;
+
+- (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+
 - (void)managerDidLoadInterstitial:(MPInterstitialAdManager *)manager;
 - (void)manager:(MPInterstitialAdManager *)manager
 didFailToLoadInterstitialWithError:(NSError *)error;

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManagerDelegate.h
@@ -18,11 +18,10 @@
 - (id)interstitialDelegate;
 
 - (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass;
-- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass;
+- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass error:(NSError*)error;
 
 - (void)managerDidLoadInterstitial:(MPInterstitialAdManager *)manager;
-- (void)manager:(MPInterstitialAdManager *)manager
-didFailToLoadInterstitialWithError:(NSError *)error;
+- (void)manager:(MPInterstitialAdManager *)manager didFailToLoadInterstitialWithError:(NSError *)error;
 - (void)managerWillPresentInterstitial:(MPInterstitialAdManager *)manager;
 - (void)managerDidPresentInterstitial:(MPInterstitialAdManager *)manager;
 - (void)managerWillDismissInterstitial:(MPInterstitialAdManager *)manager;

--- a/MoPubSDK/MPAdView.h
+++ b/MoPubSDK/MPAdView.h
@@ -242,7 +242,6 @@ typedef enum
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
- * @param creativeId The creativeId of the Ad being loaded.
  */
 - (void)bannerWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
@@ -251,9 +250,9 @@ typedef enum
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
- * @param creativeId The creativeId of the Ad being loaded.
+ * @param error The error that occurred during the load.
  */
-- (void)bannerDidFailAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+- (void)bannerDidFailAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass error:(NSError*)error;
 
 /** @name Detecting When a Banner Ad is Loaded */
 

--- a/MoPubSDK/MPAdView.h
+++ b/MoPubSDK/MPAdView.h
@@ -237,6 +237,24 @@ typedef enum
 
 @optional
 
+/**
+ * This method is called before an ad attempts to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param creativeId The creativeId of the Ad being loaded.
+ */
+- (void)bannerWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+
+/**
+ * This method is called after an ad attempt fails to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param creativeId The creativeId of the Ad being loaded.
+ */
+- (void)bannerDidFailAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+
 /** @name Detecting When a Banner Ad is Loaded */
 
 /**

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -143,6 +143,18 @@
     [self setAdContentView:nil];
 }
 
+- (void)bannerWillStartAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass {
+    if ([self.delegate respondsToSelector:@selector(bannerWillStartAttemptForAdUnitId:withCustomEventClass:)]) {
+        [self.delegate bannerWillStartAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass];
+    }
+}
+
+- (void)bannerDidFailAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass {
+    if ([self.delegate respondsToSelector:@selector(bannerDidFailAttemptForAdUnitId:withCustomEventClass:)]) {
+        [self.delegate bannerDidFailAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass];
+    }
+}
+
 - (void)managerDidFailToLoadAd
 {
     if ([self.delegate respondsToSelector:@selector(adViewDidFailToLoadAd:)]) {

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -143,15 +143,17 @@
     [self setAdContentView:nil];
 }
 
-- (void)bannerWillStartAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass {
+- (void)bannerWillStartAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass
+{
     if ([self.delegate respondsToSelector:@selector(bannerWillStartAttemptForAdUnitId:withCustomEventClass:)]) {
         [self.delegate bannerWillStartAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass];
     }
 }
 
-- (void)bannerDidFailAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass {
-    if ([self.delegate respondsToSelector:@selector(bannerDidFailAttemptForAdUnitId:withCustomEventClass:)]) {
-        [self.delegate bannerDidFailAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass];
+- (void)bannerDidFailAttemptForAdManager:(MPBannerAdManager *)manager withCustomEventClass:(NSString *)customEventClass error:(NSError *)error
+{
+    if ([self.delegate respondsToSelector:@selector(bannerDidFailAttemptForAdUnitId:withCustomEventClass:error:)]) {
+        [self.delegate bannerDidFailAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass error:error];
     }
 }
 

--- a/MoPubSDK/MPInterstitialAdController.h
+++ b/MoPubSDK/MPInterstitialAdController.h
@@ -168,7 +168,6 @@
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
- * @param creativeId The creativeId of the Ad being loaded.
  */
 - (void)interstitialWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
@@ -177,9 +176,9 @@
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
- * @param creativeId The creativeId of the Ad being loaded.
+ * @param error The error that occurred during the load.
  */
-- (void)interstitialDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+- (void)interstitialDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass error:(NSError*)error;
 
 /**
  * Sent when an interstitial ad object successfully loads an ad.

--- a/MoPubSDK/MPInterstitialAdController.h
+++ b/MoPubSDK/MPInterstitialAdController.h
@@ -170,7 +170,7 @@
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  * @param creativeId The creativeId of the Ad being loaded.
  */
-- (void)interstitialWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+- (void)interstitialWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
 /**
  * This method is called after an ad attempt fails to load.
@@ -179,7 +179,7 @@
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  * @param creativeId The creativeId of the Ad being loaded.
  */
-- (void)interstitialDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+- (void)interstitialDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
 /**
  * Sent when an interstitial ad object successfully loads an ad.

--- a/MoPubSDK/MPInterstitialAdController.h
+++ b/MoPubSDK/MPInterstitialAdController.h
@@ -164,6 +164,24 @@
 /** @name Detecting When an Interstitial Ad is Loaded */
 
 /**
+ * This method is called before an ad attempts to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param creativeId The creativeId of the Ad being loaded.
+ */
+- (void)interstitialWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+
+/**
+ * This method is called after an ad attempt fails to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param creativeId The creativeId of the Ad being loaded.
+ */
+- (void)interstitialDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+
+/**
  * Sent when an interstitial ad object successfully loads an ad.
  *
  * @param interstitial The interstitial ad object sending the message.

--- a/MoPubSDK/MPInterstitialAdController.m
+++ b/MoPubSDK/MPInterstitialAdController.m
@@ -117,6 +117,20 @@
     return self.delegate;
 }
 
+- (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId
+{
+    if ([self.delegate respondsToSelector:@selector(manager:willStartInterstitialAttemptWithCustomEventClass:creativeId:)]) {
+        [self.delegate interstitialWillStartAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass creativeId:creativeId];
+    }
+}
+
+- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId
+{
+    if ([self.delegate respondsToSelector:@selector(manager:didFailInterstitialAttemptWithCustomEventClass:creativeId:)]) {
+        [self.delegate interstitialDidFailAttemptForAdUnitID:self.adUnitId withCustomEventClass:customEventClass creativeId:creativeId];
+    }
+}
+
 - (void)managerDidLoadInterstitial:(MPInterstitialAdManager *)manager
 {
     if ([self.delegate respondsToSelector:@selector(interstitialDidLoadAd:)]) {

--- a/MoPubSDK/MPInterstitialAdController.m
+++ b/MoPubSDK/MPInterstitialAdController.m
@@ -117,17 +117,17 @@
     return self.delegate;
 }
 
-- (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId
+- (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass
 {
-    if ([self.delegate respondsToSelector:@selector(manager:willStartInterstitialAttemptWithCustomEventClass:creativeId:)]) {
-        [self.delegate interstitialWillStartAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass creativeId:creativeId];
+    if ([self.delegate respondsToSelector:@selector(manager:willStartInterstitialAttemptWithCustomEventClass:)]) {
+        [self.delegate interstitialWillStartAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass];
     }
 }
 
-- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId
+- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass
 {
-    if ([self.delegate respondsToSelector:@selector(manager:didFailInterstitialAttemptWithCustomEventClass:creativeId:)]) {
-        [self.delegate interstitialDidFailAttemptForAdUnitID:self.adUnitId withCustomEventClass:customEventClass creativeId:creativeId];
+    if ([self.delegate respondsToSelector:@selector(manager:didFailInterstitialAttemptWithCustomEventClass:)]) {
+        [self.delegate interstitialDidFailAttemptForAdUnitID:self.adUnitId withCustomEventClass:customEventClass];
     }
 }
 

--- a/MoPubSDK/MPInterstitialAdController.m
+++ b/MoPubSDK/MPInterstitialAdController.m
@@ -119,15 +119,15 @@
 
 - (void)manager:(MPInterstitialAdManager *)manager willStartInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass
 {
-    if ([self.delegate respondsToSelector:@selector(manager:willStartInterstitialAttemptWithCustomEventClass:)]) {
+    if ([self.delegate respondsToSelector:@selector(interstitialWillStartAttemptForAdUnitId:withCustomEventClass:)]) {
         [self.delegate interstitialWillStartAttemptForAdUnitId:self.adUnitId withCustomEventClass:customEventClass];
     }
 }
 
-- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass
+- (void)manager:(MPInterstitialAdManager *)manager didFailInterstitialAttemptWithCustomEventClass:(NSString*)customEventClass error:(NSError*)error
 {
-    if ([self.delegate respondsToSelector:@selector(manager:didFailInterstitialAttemptWithCustomEventClass:)]) {
-        [self.delegate interstitialDidFailAttemptForAdUnitID:self.adUnitId withCustomEventClass:customEventClass];
+    if ([self.delegate respondsToSelector:@selector(interstitialDidFailAttemptForAdUnitID:withCustomEventClass:error:)]) {
+        [self.delegate interstitialDidFailAttemptForAdUnitID:self.adUnitId withCustomEventClass:customEventClass error:error];
     }
 }
 

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
@@ -87,7 +87,7 @@
 
 @protocol MPRewardedVideoAdManagerDelegate <NSObject>
 - (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
-- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass error:(NSError*)error;
 - (void)rewardedVideoDidLoadForAdManager:(MPRewardedVideoAdManager *)manager;
 - (void)rewardedVideoDidFailToLoadForAdManager:(MPRewardedVideoAdManager *)manager error:(NSError *)error;
 - (void)rewardedVideoDidExpireForAdManager:(MPRewardedVideoAdManager *)manager;

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
@@ -87,6 +87,8 @@
 
 @protocol MPRewardedVideoAdManagerDelegate <NSObject>
 
+- (void)rewardedVideoWillStartAttemptForAdapter:(MPRewardedVideoAdManager *)manager;
+- (void)rewardedVideoDidFailAttemptForAdapter:(MPRewardedVideoAdManager *)manager;
 - (void)rewardedVideoDidLoadForAdManager:(MPRewardedVideoAdManager *)manager;
 - (void)rewardedVideoDidFailToLoadForAdManager:(MPRewardedVideoAdManager *)manager error:(NSError *)error;
 - (void)rewardedVideoDidExpireForAdManager:(MPRewardedVideoAdManager *)manager;

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
@@ -86,9 +86,8 @@
 @end
 
 @protocol MPRewardedVideoAdManagerDelegate <NSObject>
-
-- (void)rewardedVideoWillStartAttemptForAdapter:(MPRewardedVideoAdManager *)manager;
-- (void)rewardedVideoDidFailAttemptForAdapter:(MPRewardedVideoAdManager *)manager;
+- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString*)creativeId;
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString*)creativeId;
 - (void)rewardedVideoDidLoadForAdManager:(MPRewardedVideoAdManager *)manager;
 - (void)rewardedVideoDidFailToLoadForAdManager:(MPRewardedVideoAdManager *)manager error:(NSError *)error;
 - (void)rewardedVideoDidExpireForAdManager:(MPRewardedVideoAdManager *)manager;

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.h
@@ -86,8 +86,8 @@
 @end
 
 @protocol MPRewardedVideoAdManagerDelegate <NSObject>
-- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString*)creativeId;
-- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString*)creativeId;
+- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass;
 - (void)rewardedVideoDidLoadForAdManager:(MPRewardedVideoAdManager *)manager;
 - (void)rewardedVideoDidFailToLoadForAdManager:(MPRewardedVideoAdManager *)manager error:(NSError *)error;
 - (void)rewardedVideoDidExpireForAdManager:(MPRewardedVideoAdManager *)manager;

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
@@ -204,7 +204,9 @@
 
     self.adapter = adapter;
     
-    [self.delegate rewardedVideoWillStartAttemptForAdapter:self];
+    [self.delegate rewardedVideoWillStartAttemptForAdManager:self
+                                        withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
+                                               creativeId:self.configuration.creativeId];
     [self.adapter getAdWithConfiguration:self.configuration];
 }
 
@@ -238,7 +240,9 @@
 
 - (void)rewardedVideoDidFailToLoadForAdapter:(MPRewardedVideoAdapter *)adapter error:(NSError *)error
 {
-    [self.delegate rewardedVideoDidFailAttemptForAdapter:self];
+    [self.delegate rewardedVideoDidFailAttemptForAdManager:self
+                                      withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
+                                             creativeId:self.configuration.creativeId];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
@@ -203,6 +203,8 @@
     }
 
     self.adapter = adapter;
+    
+    [self.delegate rewardedVideoWillStartAttemptForAdapter:self];
     [self.adapter getAdWithConfiguration:self.configuration];
 }
 
@@ -236,6 +238,7 @@
 
 - (void)rewardedVideoDidFailToLoadForAdapter:(MPRewardedVideoAdapter *)adapter error:(NSError *)error
 {
+    [self.delegate rewardedVideoDidFailAttemptForAdapter:self];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
@@ -140,7 +140,7 @@
             self.configuration.selectedReward = reward;
         }
     }
-
+    
     [self.adapter presentRewardedVideoFromViewController:viewController customData:customData];
 }
 
@@ -205,8 +205,7 @@
     self.adapter = adapter;
     
     [self.delegate rewardedVideoWillStartAttemptForAdManager:self
-                                        withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
-                                               creativeId:self.configuration.creativeId];
+                                        withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)];
     [self.adapter getAdWithConfiguration:self.configuration];
 }
 
@@ -241,8 +240,7 @@
 - (void)rewardedVideoDidFailToLoadForAdapter:(MPRewardedVideoAdapter *)adapter error:(NSError *)error
 {
     [self.delegate rewardedVideoDidFailAttemptForAdManager:self
-                                      withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
-                                             creativeId:self.configuration.creativeId];
+                                      withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
@@ -240,7 +240,8 @@
 - (void)rewardedVideoDidFailToLoadForAdapter:(MPRewardedVideoAdapter *)adapter error:(NSError *)error
 {
     [self.delegate rewardedVideoDidFailAttemptForAdManager:self
-                                      withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)];
+                                      withCustomEventClass:NSStringFromClass(self.configuration.customEventClass)
+                                                     error:error];
     self.ready = NO;
     self.loading = NO;
     [self loadAdWithURL:self.configuration.failoverURL];

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.h
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.h
@@ -158,7 +158,7 @@
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  */
-- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
 
 /**
  * This method is called after an ad attempt fails to load.
@@ -166,7 +166,7 @@
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  */
-- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
 
 /**
  * This method is called after an ad loads successfully.

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.h
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.h
@@ -176,7 +176,7 @@
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  */
-- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
 /**
  * This method is called after an ad attempt fails to load.
@@ -184,7 +184,7 @@
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  */
-- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
 /**
  * This method is called after an ad loads successfully.

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.h
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.h
@@ -157,6 +157,24 @@
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param creativeId The creativeId of the Ad being loaded.
+ */
+- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+
+/**
+ * This method is called after an ad attempt fails to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param creativeId The creativeId of the Ad being loaded.
+ */
+- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
+
+/**
+ * This method is called before an ad attempts to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  */
 - (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
 

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.h
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.h
@@ -157,24 +157,6 @@
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
- * @param creativeId The creativeId of the Ad being loaded.
- */
-- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
-
-/**
- * This method is called after an ad attempt fails to load.
- *
- * @param adUnitID The ad unit ID of the ad associated with the event.
- * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
- * @param creativeId The creativeId of the Ad being loaded.
- */
-- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass creativeId:(NSString *)creativeId;
-
-/**
- * This method is called before an ad attempts to load.
- *
- * @param adUnitID The ad unit ID of the ad associated with the event.
- * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
  */
 - (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
 
@@ -183,8 +165,9 @@
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.
  * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ * @param error The error that occurred during the load.
  */
-- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass error:(NSError *)error;
 
 /**
  * This method is called after an ad loads successfully.

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.h
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.h
@@ -153,6 +153,22 @@
 @optional
 
 /**
+ * This method is called before an ad attempts to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ */
+- (void)rewardedVideoWillStartAttemptForAdUnitId:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+
+/**
+ * This method is called after an ad attempt fails to load.
+ *
+ * @param adUnitID The ad unit ID of the ad associated with the event.
+ * @param customEventClass The MPCustomEvent class name to identify the AdNetwork.
+ */
+- (void)rewardedVideoDidFailAttemptForAdUnitID:(NSString *)adUnitID withCustomEventClass:(NSString*)customEventClass;
+
+/**
  * This method is called after an ad loads successfully.
  *
  * @param adUnitID The ad unit ID of the ad associated with the event.

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.m
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.m
@@ -191,11 +191,11 @@ static MPRewardedVideo *gSharedInstance = nil;
     }
 }
 
-- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass error:(NSError *)error
 {
     id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
-    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:)]) {
-        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass];
+    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:error:)]) {
+        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass error:error];
     }
 }
 

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.m
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.m
@@ -183,6 +183,22 @@ static MPRewardedVideo *gSharedInstance = nil;
 
 #pragma mark - MPRewardedVideoAdManagerDelegate
 
+- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
+{
+    id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
+    if ([delegate respondsToSelector:@selector(rewardedVideoWillStartAttemptForAdUnitId:withCustomEventClass:)]) {
+        [delegate rewardedVideoWillStartAttemptForAdUnitId:manager.adUnitID withCustomEventClass:customEventClass];
+    }
+}
+
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
+{
+    id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
+    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:)]) {
+        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass];
+    }
+}
+
 - (void)rewardedVideoDidLoadForAdManager:(MPRewardedVideoAdManager *)manager
 {
     id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.m
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.m
@@ -183,19 +183,19 @@ static MPRewardedVideo *gSharedInstance = nil;
 
 #pragma mark - MPRewardedVideoAdManagerDelegate
 
-- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
+- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString *)creativeId
 {
     id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
-    if ([delegate respondsToSelector:@selector(rewardedVideoWillStartAttemptForAdUnitId:withCustomEventClass:)]) {
-        [delegate rewardedVideoWillStartAttemptForAdUnitId:manager.adUnitID withCustomEventClass:customEventClass];
+    if ([delegate respondsToSelector:@selector(rewardedVideoWillStartAttemptForAdUnitId:withCustomEventClass:creativeId:)]) {
+        [delegate rewardedVideoWillStartAttemptForAdUnitId:manager.adUnitID withCustomEventClass:customEventClass creativeId:creativeId];
     }
 }
 
-- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString *)creativeId
 {
     id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
-    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:)]) {
-        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass];
+    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:creativeId:)]) {
+        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass creativeId:creativeId];
     }
 }
 

--- a/MoPubSDK/RewardedVideo/MPRewardedVideo.m
+++ b/MoPubSDK/RewardedVideo/MPRewardedVideo.m
@@ -183,19 +183,19 @@ static MPRewardedVideo *gSharedInstance = nil;
 
 #pragma mark - MPRewardedVideoAdManagerDelegate
 
-- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString *)creativeId
+- (void)rewardedVideoWillStartAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
 {
     id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
-    if ([delegate respondsToSelector:@selector(rewardedVideoWillStartAttemptForAdUnitId:withCustomEventClass:creativeId:)]) {
-        [delegate rewardedVideoWillStartAttemptForAdUnitId:manager.adUnitID withCustomEventClass:customEventClass creativeId:creativeId];
+    if ([delegate respondsToSelector:@selector(rewardedVideoWillStartAttemptForAdUnitId:withCustomEventClass:)]) {
+        [delegate rewardedVideoWillStartAttemptForAdUnitId:manager.adUnitID withCustomEventClass:customEventClass];
     }
 }
 
-- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass creativeId:(NSString *)creativeId
+- (void)rewardedVideoDidFailAttemptForAdManager:(MPRewardedVideoAdManager *)manager withCustomEventClass:(NSString *)customEventClass
 {
     id<MPRewardedVideoDelegate> delegate = [self.delegateTable objectForKey:manager.adUnitID];
-    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:creativeId:)]) {
-        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass creativeId:creativeId];
+    if ([delegate respondsToSelector:@selector(rewardedVideoDidFailAttemptForAdUnitID:withCustomEventClass:)]) {
+        [delegate rewardedVideoDidFailAttemptForAdUnitID:manager.adUnitID withCustomEventClass:customEventClass];
     }
 }
 


### PR DESCRIPTION
Added support for attempt tracking in Banner, Interstitial and Rewarded Video. Uses existing delegates to provide two new optional methods to each AdType providing visibility into attempts started and the AdNetwork involved and attempts failed. Does not provide a specific method for attempt succeed because it is the same as the full load success. This code is not tested, but recommend to merge and test together with other features.